### PR TITLE
Add Docker setup with PostGIS service

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+npm-debug.log
+Dockerfile
+.dockerignore
+docker-compose.yml
+.git
+.gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:lts-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+ENV NODE_ENV=production
+EXPOSE 3000
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,41 @@
 # postgis
+
 PoC project to test polygon area
+
+## Running with Docker
+
+This project uses `docker-compose` to run a PostGIS database and the Node.js server.
+
+Build and start the containers:
+
+```bash
+docker-compose up --build
+```
+
+The server will be available on [http://localhost:3000](http://localhost:3000) and the database on port `5432`.
+
+### Creating the `polygon_areas` table
+
+Run the following command to open a `psql` shell inside the database container:
+
+```bash
+docker-compose exec db psql -U postgres
+```
+
+Then create the table:
+
+```sql
+CREATE TABLE polygon_areas (
+  id SERIAL PRIMARY KEY,
+  geom GEOMETRY(POLYGON, 4326)
+);
+```
+
+Exit `psql` with `\q`.
+
+### Environment variables
+
+- `POSTGRES_PASSWORD` – password for the `postgres` user (set in `docker-compose.yml`).
+- `DATABASE_URL` – connection string used by the server to reach the database.
+
+Both are already defined in the compose file for local development.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.8'
+services:
+  db:
+    image: postgis/postgis:latest
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_PASSWORD: postgres
+  server:
+    build: .
+    ports:
+      - "3000:3000"
+    depends_on:
+      - db
+    environment:
+      DATABASE_URL: postgres://postgres:postgres@db:5432/postgres


### PR DESCRIPTION
## Summary
- add a production Dockerfile for the Node server
- add docker-compose setup with PostGIS
- ignore build artifacts in `.dockerignore`
- document how to use Docker and create the `polygon_areas` table

## Testing
- `docker-compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844e3c224c8832f9ca1eccf7d035e01