### PR TITLE
Add basic PostGIS API server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # postgis
 
-PoC project to test polygon area
+PoC project to test polygon area with a small Node.js server.
 
 ## Running with Docker
 
@@ -16,22 +16,23 @@ The server will be available on [http://localhost:3000](http://localhost:3000) a
 
 ### Creating the `polygon_areas` table
 
-Run the following command to open a `psql` shell inside the database container:
+A SQL script is provided in `sql/create_polygon_areas.sql`:
 
 ```bash
-docker-compose exec db psql -U postgres
+docker-compose exec db psql -U postgres -f /app/sql/create_polygon_areas.sql
 ```
 
-Then create the table:
+### API endpoint
 
-```sql
-CREATE TABLE polygon_areas (
-  id SERIAL PRIMARY KEY,
-  geom GEOMETRY(POLYGON, 4326)
-);
+`POST /check-location`
+
+Body:
+
+```json
+{ "lat": 10.0, "lon": 20.0 }
 ```
 
-Exit `psql` with `\q`.
+The endpoint returns `{ "inside": true, "polygonId": 1 }` when the point is inside a stored polygon or `{ "inside": false }` otherwise.
 
 ### Environment variables
 
@@ -39,3 +40,12 @@ Exit `psql` with `\q`.
 - `DATABASE_URL` – connection string used by the server to reach the database.
 
 Both are already defined in the compose file for local development.
+
+### Tests
+
+Run the unit tests with:
+
+```bash
+npm test
+```
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "postgis-server",
+  "version": "1.0.0",
+  "description": "Minimal API server with PostGIS integration",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "jest"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "pg": "^8.11.1"
+  },
+  "devDependencies": {
+    "jest": "^29.6.1",
+    "supertest": "^6.3.3"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,48 @@
+const express = require('express');
+const bodyParser = require('body-parser');
+const { Pool } = require('pg');
+
+function createApp(pool = new Pool({
+  connectionString: process.env.DATABASE_URL || 'postgres://postgres:postgres@localhost:5432/postgres'
+})) {
+  const app = express();
+  app.use(bodyParser.json());
+
+  async function checkPoint(lat, lon) {
+    const query = `SELECT id FROM polygon_areas
+      WHERE ST_Contains(geom, ST_SetSRID(ST_MakePoint($1, $2), 4326))
+      LIMIT 1`;
+    const { rows } = await pool.query(query, [lon, lat]);
+    if (rows.length > 0) {
+      return { inside: true, polygonId: rows[0].id };
+    }
+    return { inside: false };
+  }
+
+  app.post('/check-location', async (req, res) => {
+    const { lat, lon } = req.body;
+    if (typeof lat !== 'number' || typeof lon !== 'number') {
+      return res.status(400).json({ error: 'lat and lon required' });
+    }
+    try {
+      const result = await checkPoint(lat, lon);
+      res.json(result);
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ error: 'server error' });
+    }
+  });
+
+  app.checkPoint = checkPoint;
+  return app;
+}
+
+if (require.main === module) {
+  const app = createApp();
+  const port = process.env.PORT || 3000;
+  app.listen(port, () => {
+    console.log(`Server listening on port ${port}`);
+  });
+}
+
+module.exports = { createApp };

--- a/sql/create_polygon_areas.sql
+++ b/sql/create_polygon_areas.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS polygon_areas (
+  id SERIAL PRIMARY KEY,
+  geom GEOMETRY(POLYGON, 4326)
+);

--- a/tests/polygon.test.js
+++ b/tests/polygon.test.js
@@ -1,0 +1,30 @@
+const request = require('supertest');
+const { createApp } = require('../server');
+
+function mockPool(returnRows) {
+  return {
+    query: jest.fn().mockResolvedValue({ rows: returnRows })
+  };
+}
+
+describe('POST /check-location', () => {
+  test('returns inside true when point is inside a polygon', async () => {
+    const pool = mockPool([{ id: 1 }]);
+    const app = createApp(pool);
+    const res = await request(app)
+      .post('/check-location')
+      .send({ lat: 10, lon: 20 });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ inside: true, polygonId: 1 });
+  });
+
+  test('returns inside false when point is outside polygons', async () => {
+    const pool = mockPool([]);
+    const app = createApp(pool);
+    const res = await request(app)
+      .post('/check-location')
+      .send({ lat: 10, lon: 20 });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ inside: false });
+  });
+});


### PR DESCRIPTION
## Summary
- add Node.js server with endpoint to query polygons via PostGIS
- provide SQL creation script and usage docs
- add Jest tests that mock Postgres queries

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844e60273f8832fb4b94f135737c13b