### PR TITLE
Create PostGIS extension on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The endpoint returns `{ "inside": true, "polygonId": 1 }` when the point is insi
 
 Swagger UI is available at `http://localhost:3000/api-docs` when the server is running.
 
-The server automatically ensures the database and `polygon_areas` table exist when it starts.
+The server automatically ensures the database, creates the PostGIS extension if needed, and ensures the `polygon_areas` table exist when it starts.
 
 ### Environment variables
 

--- a/server.js
+++ b/server.js
@@ -46,10 +46,12 @@ function createApp(pool, connectionString) {
   async function runMigrations() {
     const sql = fs.readFileSync(require('path').join(__dirname, 'sql', 'create_polygon_areas.sql'), 'utf8');
     try {
+      await pool.query('CREATE EXTENSION IF NOT EXISTS postgis');
       await pool.query(sql);
       console.log('Database migrations applied');
     } catch (err) {
       console.error('Migration failed:', err);
+      throw err;
     }
   }
 


### PR DESCRIPTION
## Summary
- run `CREATE EXTENSION IF NOT EXISTS postgis` in migrations
- throw migration errors to stop startup when they occur
- note automatic PostGIS extension creation in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68456168ddc0832fa2dfd9465585b27b