### PR TITLE
Seed default circle after migrations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,8 @@ PGADMIN_DEFAULT_EMAIL=admin@example.com
 PGADMIN_DEFAULT_PASSWORD=admin
 # Connection string used by the Node.js server
 DATABASE_URL=postgres://postgres:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
+
+# Default polygon inserted after migrations
+CIRCLE_LAT=40.0
+CIRCLE_LON=-74.0
+CIRCLE_NAME=Home area

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ docker-compose exec db psql -U postgres \
   -f /app/sql/create_circle_polygon.sql
 ```
 
+The server automatically adds a circle polygon during startup using the
+`CIRCLE_LAT`, `CIRCLE_LON`, and `CIRCLE_NAME` environment variables.
+
 ### API endpoints
 
 `POST /polygons` – create a new polygon area
@@ -81,6 +84,9 @@ Configuration is read from the `.env` file. Important variables include:
 - `POSTGRES_PASSWORD` – password for the `postgres` user
 - `POSTGRES_DB` – name of the database (defaults to `gis_database`)
 - `DATABASE_URL` – connection string used by the server
+- `CIRCLE_LAT` – latitude of the default circle polygon (default `40.0`)
+- `CIRCLE_LON` – longitude of the default circle polygon (default `-74.0`)
+- `CIRCLE_NAME` – name for the inserted circle polygon (default `Home area`)
 
 All variables have defaults in `.env.example` for local development.
 

--- a/server.js
+++ b/server.js
@@ -44,10 +44,25 @@ function createApp(pool, connectionString) {
   }
 
   async function runMigrations() {
-    const sql = fs.readFileSync(require('path').join(__dirname, 'sql', 'create_polygon_areas.sql'), 'utf8');
+    const path = require('path');
+    const createSql = fs.readFileSync(path.join(__dirname, 'sql', 'create_polygon_areas.sql'), 'utf8');
+    const insertSql = `INSERT INTO polygon_areas(name, geom)
+      VALUES (
+        $1,
+        ST_Buffer(
+          ST_SetSRID(ST_MakePoint($2, $3), 4326)::geography,
+          1000
+        )::geometry
+      )`;
+
+    const defaultLat = parseFloat(process.env.CIRCLE_LAT || '40.0');
+    const defaultLon = parseFloat(process.env.CIRCLE_LON || '-74.0');
+    const defaultName = process.env.CIRCLE_NAME || 'Home area';
+
     try {
       await pool.query('CREATE EXTENSION IF NOT EXISTS postgis');
-      await pool.query(sql);
+      await pool.query(createSql);
+      await pool.query(insertSql, [defaultName, defaultLon, defaultLat]);
       console.log('Database migrations applied');
     } catch (err) {
       console.error('Migration failed:', err);

--- a/tests/polygon.test.js
+++ b/tests/polygon.test.js
@@ -61,3 +61,14 @@ describe('POST /polygons', () => {
     expect(res.status).toBe(400);
   });
 });
+
+describe('runMigrations', () => {
+  test('creates table and inserts default circle', async () => {
+    const pool = { query: jest.fn().mockResolvedValue({ rows: [] }) };
+    const app = createApp(pool);
+    await app.runMigrations();
+    expect(pool.query).toHaveBeenCalledWith('CREATE EXTENSION IF NOT EXISTS postgis');
+    expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('CREATE TABLE IF NOT EXISTS polygon_areas'));
+    expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('INSERT INTO polygon_areas'), expect.any(Array));
+  });
+});


### PR DESCRIPTION
## Summary
- insert a default circle polygon during migrations
- support new `CIRCLE_*` env variables
- document the environment variables and default behaviour
- test the new migration logic

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68457bcc2ae8832f8f27c8df40d991c1