### PR TITLE
Update test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,10 +92,17 @@ All variables have defaults in `.env.example` for local development.
 
 ### Tests
 
-Run the unit tests with:
+Install dependencies and run the unit tests with:
 
 ```bash
+npm install
 npm test
+```
+
+If using Docker, the tests can be executed inside the server container:
+
+```bash
+docker-compose run --rm server npm test
 ```
 
 ### License


### PR DESCRIPTION
## Summary
- clarify needing `npm install` before running tests
- show docker alternative for running tests

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845805a0dc4832fb7339265f5ae3aaf